### PR TITLE
Override refetchVariables with fetchVariables

### DIFF
--- a/packages/react-relay/modern/ReactRelayPaginationContainer.js
+++ b/packages/react-relay/modern/ReactRelayPaginationContainer.js
@@ -708,8 +708,8 @@ function createContainerWithFragments<
         componentName,
       );
       fetchVariables = {
-        ...fetchVariables,
         ...this._refetchVariables,
+        ...fetchVariables,
       };
 
       const cacheConfig: ?CacheConfig = options


### PR DESCRIPTION
This ensures that the proper cursor is used after `refetchConnection` is called.